### PR TITLE
Add PR comments to failed actions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # pinned version of the Alpine-tagged 'go' image
 FROM golang:1.13-alpine
 
+# install requirements
+RUN apk add --update --no-cache bash ca-certificates curl jq
+
 # grab tfsec from GitHub (taken from README.md)
 RUN env GO111MODULE=on go get -u github.com/liamg/tfsec/cmd/tfsec
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,23 @@ The action requires the https://github.com/actions/checkout before to download t
 
 ## Inputs
 
-None
+* `tfsec_actions_comment` - (Optional) Whether or not to comment on GitHub pull requests. Defaults to `true`.
 
 ## Outputs
 
 None
 
 ## Example usage
-```
+
+```yaml
 steps:
   - uses: actions/checkout@v1
   - uses: triat/terraform-security-scan@v1
+```
+
+To allow the action to add a comment to a PR when it fails you need to append the `GITHUB_TOKEN` variable to the tfsec action:
+
+```yaml
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/README.md
+++ b/README.md
@@ -16,8 +16,16 @@ None
 
 ```yaml
 steps:
-  - uses: actions/checkout@v1
+  - uses: actions/checkout@master
   - uses: triat/terraform-security-scan@v1
+```
+
+The above example uses a tagged version (`v1`), you can also opt to use the `master` branch:
+
+```yaml
+steps:
+  - uses: actions/checkout@master
+  - uses: triat/terraform-security-scan@master
 ```
 
 To allow the action to add a comment to a PR when it fails you need to append the `GITHUB_TOKEN` variable to the tfsec action:
@@ -25,4 +33,20 @@ To allow the action to add a comment to a PR when it fails you need to append th
 ```yaml
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Full example:
+
+```yaml
+jobs:
+  tfsec:
+    name: tfsec
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Terraform security scan
+        uses: triat/terraform-security-scan@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,10 @@
 # action.yml
 name: 'Terraform security scan'
 description: 'Scan your terraform code with tfsec'
+inputs:
+  tfsec_actions_comment:
+    description: 'Whether or not to comment on pull requests.'
+    default: true
 runs:
   using: 'docker'
-  image: 'docker://triat/tfsec:latest'
+  image: './Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,37 @@
-#!/bin/sh -l
+#!/bin/bash
 
-/go/bin/tfsec /github/workspace
+TFSEC_OUTPUT=$(/go/bin/tfsec /github/workspace)
+TFSEC_EXITCODE=${?}
+
+# Exit code of 0 indicates success.
+if [ ${TFSEC_EXITCODE} -eq 0 ]; then
+  TFSEC_STATUS="Success"
+else
+  TFSEC_STATUS="Failed"
+fi
+
+# Print output.
+echo "${TFSEC_OUTPUT}"
+
+# Comment on the pull request if necessary.
+if [ "${INPUT_TFSEC_ACTIONS_COMMENT}" == "1" ] || [ "${INPUT_TFSEC_ACTIONS_COMMENT}" == "true" ]; then
+  TFSEC_COMMENT=1
+else
+  TFSEC_COMMENT=0
+fi
+
+if [ "${GITHUB_EVENT_NAME}" == "pull_request" ] && [ -n "${GITHUB_TOKEN}" ] && [ "${TFSEC_COMMENT}" == "1" ] && [ "${TFSEC_EXITCODE}" != "0" ]; then
+    COMMENT="#### \`Terraform Security Scan\` ${TFSEC_STATUS}
+<details><summary>Show Output</summary>
+
+\`\`\`hcl
+$(/go/bin/tfsec /github/workspace --no-colour)
+\`\`\`
+
+</details>"
+  PAYLOAD=$(echo "${COMMENT}" | jq -R --slurp '{body: .}')
+  URL=$(jq -r .pull_request.comments_url "${GITHUB_EVENT_PATH}")
+  echo "${PAYLOAD}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${URL}" > /dev/null
+fi
+
+exit $TFSEC_EXITCODE


### PR DESCRIPTION
Hello, This PR adds the possibility for the Action to add a comment to a PR when the action fails. I've tested my fork against a private repo and result looks good. The HCL formatted markdown is just to provide some colour in the output, it could be anything.

I also added some README updates in a separate commit that can be omitted if preferred.