### PR TITLE
Add input to specify the terraform working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The action requires the https://github.com/actions/checkout before to download t
 ## Inputs
 
 * `tfsec_actions_comment` - (Optional) Whether or not to comment on GitHub pull requests. Defaults to `true`.
+* `tfsec_actions_working_dir` - (Optional) Terraform working directory location. Defaults to `'.'`.
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,9 @@ inputs:
   tfsec_actions_comment:
     description: 'Whether or not to comment on pull requests.'
     default: true
+  tfsec_actions_working_dir:
+    description: 'Terraform working directory.'
+    default: '.'
 runs:
   using: 'docker'
   image: './Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
-TFSEC_OUTPUT=$(/go/bin/tfsec /github/workspace)
+# Comment on the pull request if necessary.
+if [ "${INPUT_TFSEC_ACTIONS_WORKING_DIR}" != "" ] && [ "${INPUT_TFSEC_ACTIONS_WORKING_DIR}" != "." ]; then
+  TFSEC_WORKING_DIR="/github/workspace/${INPUT_TFSEC_ACTIONS_WORKING_DIR}"
+else
+  TFSEC_WORKING_DIR="/github/workspace/"
+fi
+
+TFSEC_OUTPUT=$(/go/bin/tfsec ${TFSEC_WORKING_DIR})
 TFSEC_EXITCODE=${?}
 
 # Exit code of 0 indicates success.


### PR DESCRIPTION
Hello, I've got a private repository with multiple terraform environments - I've been finding it useful to run tfsec only against specific environments rather than all of them from the root of the repo.
