### PR TITLE
Revert tfsec to 0.19.0.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM golang:1.13-alpine
 RUN apk add --update --no-cache bash ca-certificates curl jq
 
 # grab tfsec from GitHub (taken from README.md)
-RUN env GO111MODULE=on go get -u github.com/liamg/tfsec/cmd/tfsec
+RUN env GO111MODULE=on go get -u github.com/liamg/tfsec/cmd/tfsec@v.0.19.0
 
 COPY entrypoint.sh /entrypoint.sh
 # set the default entrypoint -- when this container is run, use this command


### PR DESCRIPTION
Reverts tfsec to the last working version (as tfsec > 0.19 hangs indefinitely).
Relates to https://github.com/liamg/tfsec/issues/113.