### PR TITLE
Add the possibility to exclude errors and warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Terraform security check action
 
-This action runs https://github.com/liamg/tfsec on `$GITHUB_WORKSPACE`. This is a security check on your terraform repository. 
+This action runs https://github.com/liamg/tfsec on `$GITHUB_WORKSPACE`. This is a security check on your terraform repository.
 
-The action requires the https://github.com/actions/checkout before to download the content of your repo inside the docker. 
+The action requires the https://github.com/actions/checkout before to download the content of your repo inside the docker.
 
 ## Inputs
 
 * `tfsec_actions_comment` - (Optional) Whether or not to comment on GitHub pull requests. Defaults to `true`.
 * `tfsec_actions_working_dir` - (Optional) Terraform working directory location. Defaults to `'.'`.
+* `tfsec_exclude` - (Optional) Provide checks via , without space to exclude from run. No default
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
     description: 'Terraform working directory.'
     required: false
     default: '.'
+  tfsec_exclude:
+    description: 'Provide checks via , without space to exclude from run'
+    required: false
 runs:
   using: 'docker'
   image: './Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,11 @@ else
   TFSEC_WORKING_DIR="/github/workspace/"
 fi
 
-TFSEC_OUTPUT=$(/go/bin/tfsec ${TFSEC_WORKING_DIR})
+if [[ -n "$INPUT_TFSEC_EXCLUDE" ]]; then
+  TFSEC_OUTPUT=$(/go/bin/tfsec ${TFSEC_WORKING_DIR} -e "${INPUT_TFSEC_EXCLUDE}")
+else
+  TFSEC_OUTPUT=$(/go/bin/tfsec ${TFSEC_WORKING_DIR})
+fi
 TFSEC_EXITCODE=${?}
 
 # Exit code of 0 indicates success.
@@ -32,7 +36,7 @@ if [ "${GITHUB_EVENT_NAME}" == "pull_request" ] && [ -n "${GITHUB_TOKEN}" ] && [
 <details><summary>Show Output</summary>
 
 \`\`\`hcl
-$(/go/bin/tfsec /github/workspace --no-colour)
+${TFSEC_OUTPUT}
 \`\`\`
 
 </details>"


### PR DESCRIPTION
Fixing  #9 and #10 by adding a way to list error and warning codes that should be excluded from the output. It follows the way that tfsec does and accepts a list of param separated with `,` (without space) 