### PR TITLE
Allow a specific version of tfsec to be installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,6 @@ FROM golang:1.13-alpine
 # install requirements
 RUN apk add --update --no-cache bash ca-certificates curl jq
 
-# grab tfsec from GitHub (taken from README.md)
-RUN env GO111MODULE=on go get -u github.com/liamg/tfsec/cmd/tfsec@v0.19.0
-
 COPY entrypoint.sh /entrypoint.sh
 # set the default entrypoint -- when this container is run, use this command
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The action requires the https://github.com/actions/checkout before to download t
 * `tfsec_actions_comment` - (Optional) Whether or not to comment on GitHub pull requests. Defaults to `true`.
 * `tfsec_actions_working_dir` - (Optional) Terraform working directory location. Defaults to `'.'`.
 * `tfsec_exclude` - (Optional) Provide checks via , without space to exclude from run. No default
+* `tfsec_version` - (Optional) Specify the version of tfsec to install. Defaults to the latest
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
   tfsec_exclude:
     description: 'Provide checks via , without space to exclude from run'
     required: false
+  tfsec_version:
+    description: 'Specify the version of tfsec to install'
+    required: false
 runs:
   using: 'docker'
   image: './Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,13 @@ else
   TFSEC_WORKING_DIR="/github/workspace/"
 fi
 
+# grab tfsec from GitHub (taken from README.md)
+if [[ -n "$INPUT_TFSEC_VERSION" ]]; then
+  env GO111MODULE=on go get -u github.com/liamg/tfsec/cmd/tfsec@"${INPUT_TFSEC_VERSION}"
+else
+  env GO111MODULE=on go get -u github.com/liamg/tfsec/cmd/tfsec
+fi
+
 if [[ -n "$INPUT_TFSEC_EXCLUDE" ]]; then
   TFSEC_OUTPUT=$(/go/bin/tfsec ${TFSEC_WORKING_DIR} -e "${INPUT_TFSEC_EXCLUDE}")
 else


### PR DESCRIPTION
Adding `tfsec_version` parameter to allow the installation of a specific version if wanted/needed. The reason why it is not in the docker file is that this is not possible right now without a hacky double docker generation.

This PR tries to fill the requirement of #4 