### PR TITLE
rename tfsec location: liamg/tfsec -> tfsec/tfsec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Master CI](https://github.com/triat/terraform-security-scan/workflows/Master%20CI/badge.svg?branch=master)
 # Terraform security check action
 
-This action runs https://github.com/liamg/tfsec on `$GITHUB_WORKSPACE`. This is a security check on your terraform repository.
+This action runs https://github.com/tfsec/tfsec on `$GITHUB_WORKSPACE`. This is a security check on your terraform repository.
 
 The action requires the https://github.com/actions/checkout before to download the content of your repo inside the docker.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@ fi
 if [[ -n "$INPUT_TFSEC_VERSION" ]]; then
   env GO111MODULE=on go get -u github.com/tfsec/tfsec/cmd/tfsec@"${INPUT_TFSEC_VERSION}"
 else
-  env GO111MODULE=on go get -u github.com/Tfsec/tfsec/cmd/tfsec
+  env GO111MODULE=on go get -u github.com/tfsec/tfsec/cmd/tfsec
 fi
 
 if [[ -n "$INPUT_TFSEC_EXCLUDE" ]]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,9 +9,9 @@ fi
 
 # grab tfsec from GitHub (taken from README.md)
 if [[ -n "$INPUT_TFSEC_VERSION" ]]; then
-  env GO111MODULE=on go get -u github.com/liamg/tfsec/cmd/tfsec@"${INPUT_TFSEC_VERSION}"
+  env GO111MODULE=on go get -u github.com/tfsec/tfsec/cmd/tfsec@"${INPUT_TFSEC_VERSION}"
 else
-  env GO111MODULE=on go get -u github.com/liamg/tfsec/cmd/tfsec
+  env GO111MODULE=on go get -u github.com/Tfsec/tfsec/cmd/tfsec
 fi
 
 if [[ -n "$INPUT_TFSEC_EXCLUDE" ]]; then


### PR DESCRIPTION
fixes the build error:

> go: downloading github.com/liamg/tfsec v0.28.1
> go: found github.com/liamg/tfsec/cmd/tfsec in github.com/liamg/tfsec v0.28.1
> go get: github.com/liamg/tfsec@v0.28.1: parsing go.mod:
> 	module declares its path as: github.com/tfsec/tfsec
> 	        but was required as: github.com/liamg/tfsec

Fixes: #20 