### PR TITLE
update golang to 1.16 to work with tfsec 0.38.5 onwards

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # pinned version of the Alpine-tagged 'go' image
-FROM golang:1.13-alpine
+FROM golang:1.16-alpine
 
 # install requirements
 RUN apk add --update --no-cache bash ca-certificates curl jq


### PR DESCRIPTION
updated alpine base image version from golang:1.13-alpine to golang:1.16-alpine to address dependency issue with tfsec v0.38.5
Fixes https://github.com/triat/terraform-security-scan/issues/29