### PR TITLE
fix versioned installation tfsec

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,7 +23,7 @@ fi
 
 # grab tfsec from GitHub (taken from README.md)
 if [[ -n "$INPUT_TFSEC_VERSION" ]]; then
-  env GO111MODULE=on go get -u github.com/tfsec/tfsec/cmd/tfsec@"${INPUT_TFSEC_VERSION}"
+  env GO111MODULE=on go install github.com/tfsec/tfsec/cmd/tfsec@"${INPUT_TFSEC_VERSION}"
 else
   env GO111MODULE=on go get -u github.com/tfsec/tfsec/cmd/tfsec
 fi


### PR DESCRIPTION
Versioned installation should be without updating deps (-u) flag.
Update deps could cause build fail.