### PR TITLE
Fix output format and file output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-#Select the output format
-if [ "${TFSEC_OUTPUT_FILE}" != "" ]; then
-  TFSEC_FORMAT="-f ${TFSEC_OUTPUT_FILE}"
+# Select the output format
+if [ "${INPUT_TFSEC_OUTPUT_FORMAT}" != "" ]; then
+  TFSEC_FORMAT="-f ${INPUT_TFSEC_OUTPUT_FORMAT}"
 else
   TFSEC_FORMAT=""
 fi
 
-#select the output file
-if [ "${TFSEC_OUTPUT_FILE}" != "" ]; then
-  TFSEC_FILE="--out ${TFSEC_OUTPUT_FILE}"
+# select the output file
+if [ "${INPUT_TFSEC_OUTPUT_FILE}" != "" ]; then
+  TFSEC_FILE="--out ${INPUT_TFSEC_OUTPUT_FILE}"
 else
   TFSEC_FILE=""
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ else
   TFSEC_FILE=""
 fi
 
-# Comment on the pull request if necessary.
+# set working directory
 if [ "${INPUT_TFSEC_ACTIONS_WORKING_DIR}" != "" ] && [ "${INPUT_TFSEC_ACTIONS_WORKING_DIR}" != "." ]; then
   TFSEC_WORKING_DIR="/github/workspace/${INPUT_TFSEC_ACTIONS_WORKING_DIR}"
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,9 +29,9 @@ else
 fi
 
 if [[ -n "$INPUT_TFSEC_EXCLUDE" ]]; then
-  TFSEC_OUTPUT=$(/go/bin/tfsec ${TFSEC_WORKING_DIR} --no-colour -e "${INPUT_TFSEC_EXCLUDE}" "${TFSEC_FORMAT}" "${TFSEC_FILE}")
+  TFSEC_OUTPUT=$(/go/bin/tfsec ${TFSEC_WORKING_DIR} --no-colour -e "${INPUT_TFSEC_EXCLUDE}" ${TFSEC_FORMAT} ${TFSEC_FILE})
 else
-  TFSEC_OUTPUT=$(/go/bin/tfsec ${TFSEC_WORKING_DIR} --no-colour "${TFSEC_FORMAT}" "${TFSEC_FILE}")
+  TFSEC_OUTPUT=$(/go/bin/tfsec ${TFSEC_WORKING_DIR} --no-colour ${TFSEC_FORMAT} ${TFSEC_FILE})
 fi
 TFSEC_EXITCODE=${?}
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,19 +1,5 @@
 #!/bin/bash
 
-# Select the output format
-if [ "${INPUT_TFSEC_OUTPUT_FORMAT}" != "" ]; then
-  TFSEC_FORMAT="-f ${INPUT_TFSEC_OUTPUT_FORMAT}"
-else
-  TFSEC_FORMAT=""
-fi
-
-# select the output file
-if [ "${INPUT_TFSEC_OUTPUT_FILE}" != "" ]; then
-  TFSEC_FILE="--out ${INPUT_TFSEC_OUTPUT_FILE}"
-else
-  TFSEC_FILE=""
-fi
-
 # set working directory
 if [ "${INPUT_TFSEC_ACTIONS_WORKING_DIR}" != "" ] && [ "${INPUT_TFSEC_ACTIONS_WORKING_DIR}" != "." ]; then
   TFSEC_WORKING_DIR="/github/workspace/${INPUT_TFSEC_ACTIONS_WORKING_DIR}"
@@ -29,9 +15,9 @@ else
 fi
 
 if [[ -n "$INPUT_TFSEC_EXCLUDE" ]]; then
-  TFSEC_OUTPUT=$(/go/bin/tfsec ${TFSEC_WORKING_DIR} --no-colour -e "${INPUT_TFSEC_EXCLUDE}" ${TFSEC_FORMAT} ${TFSEC_FILE})
+  TFSEC_OUTPUT=$(/go/bin/tfsec ${TFSEC_WORKING_DIR} --no-colour -e "${INPUT_TFSEC_EXCLUDE}" ${INPUT_TFSEC_OUTPUT_FORMAT:+ -f "$INPUT_TFSEC_OUTPUT_FORMAT"} ${INPUT_TFSEC_OUTPUT_FILE:+ --out "$INPUT_TFSEC_OUTPUT_FILE"})
 else
-  TFSEC_OUTPUT=$(/go/bin/tfsec ${TFSEC_WORKING_DIR} --no-colour ${TFSEC_FORMAT} ${TFSEC_FILE})
+  TFSEC_OUTPUT=$(/go/bin/tfsec ${TFSEC_WORKING_DIR} --no-colour ${INPUT_TFSEC_OUTPUT_FORMAT:+ -f "$INPUT_TFSEC_OUTPUT_FORMAT"} ${INPUT_TFSEC_OUTPUT_FILE:+ --out "$INPUT_TFSEC_OUTPUT_FILE"})
 fi
 TFSEC_EXITCODE=${?}
 


### PR DESCRIPTION
Fixes issue with redirecting output to given filename in a provided format. Github Action variables are prefix with `INPUT_`. Also the `TFSEC_FORMAT` variable was appending the value of the incorrect variable.

Encapsulating variables with quotes made tfsec complain about unknown flag i.e `Error: unknown flag: --out tfsec.xml` when running `docker run --rm -e INPUT_TFSEC_OUTPUT_FORMAT="junit" -e INPUT_TFSEC_OUTPUT_FILE="/github/workspace/tfsec.xml" -v <path to terraform module>:/github/workspace:rw security/terraform-security-scan:0.1`

Fixes https://github.com/triat/terraform-security-scan/issues/37