### PR TITLE
add major tag updater

### DIFF
--- a/.github/workflows/UpdateFloatingTag.yml
+++ b/.github/workflows/UpdateFloatingTag.yml
@@ -1,0 +1,47 @@
+name: 'Update major version tag'
+
+on:
+  release:
+    types: [created, published]
+
+jobs:
+  # updates the floating tag alias for the major version.
+  release:
+    runs-on: 'ubuntu-latest'
+    steps:
+    - name: Parse higher semantic versions
+      id: semver
+      shell: bash
+      run: |
+        TAG="${{ github.ref_name }}"
+        MINOR="${TAG%.*}"
+        MAJOR="${MINOR%.*}"
+        echo "::set-output name=major::$(echo $MAJOR)"
+        echo "::set-output name=minor::$(echo $MINOR)"
+    - name: 'Update major version tag'
+      uses: 'actions/github-script@v5'
+      with:
+        script: |-
+          const sha = '${{ github.sha }}'
+          const major = '${{ steps.semver.outputs.major }}';
+          // Try to update the ref first. If that fails, it probably does not
+          // exist yet, and we should create it.
+          try {
+            await github.rest.git.updateRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `tags/${major}`,
+              sha: sha,
+              force: true,
+            });
+            core.info(`Updated ${major} to ${sha}`);
+          } catch(err) {
+            core.warning(`Failed to create ${major}: ${err}`);
+            await github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/tags/${major}`,
+              sha: sha,
+            });
+            core.info(`Created ${major} at ${sha}`);
+          }


### PR DESCRIPTION
Fixes #49 

I noticed the `v3` tag in this repo, but it does not actually represent the latest minor/patch version within the major version as the tag would imply.

From the [releasing-and-maintaining-actions docs](https://docs.github.com/en/actions/creating-actions/releasing-and-maintaining-actions#developing-and-releasing-actions):

> We recommend creating releases using semantically versioned tags – for example, v1.1.3 – and keeping major (v1) and minor (v1.1) tags current to the latest appropriate commit.

Following this pattern allows consumers of the action to specify a major version, allowing automatic updates for any bug fixes or new features. I was using `v3`, but all of my builds broke when the go 1.17 update happened in the aquasecurity repo, even after `v3.0.1` was released. For consumers who wish to tightly control the versions of actions, they are able to continue to pin their desired version down to the patch level. This is fairly standard practice among the most popular GitHub Actions, including https://github.com/actions/checkout

Additional details: as written here, this workflow will trigger automatically whenever a new release is created manually, since that is the method you mentioned is currently in use. Tested with regular manual releases, pre-releases, and draft releases that are then published