### PR TITLE
Update go from 1.17 to 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # pinned version of the Alpine-tagged 'go' image
-FROM golang:1.17-alpine
+FROM golang:1.18-alpine
 
 # install requirements
 RUN apk add --update --no-cache bash ca-certificates curl jq


### PR DESCRIPTION
to fix
```
# github.com/aquasecurity/defsec/pkg/scanners/terraform/parser/resolvers
/go/pkg/mod/github.com/aquasecurity/defsec@v0.63.0/pkg/scanners/terraform/parser/resolvers/registry.go:44:29: undefined: strings.Cut
note: module requires Go 1.18
/entrypoint.sh: line 20: /go/bin/tfsec: No such file or directory
```