### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # pinned version of the Alpine-tagged 'go' image
-FROM golang:1.22.0-alpine
+FROM golang:1.23-alpine
 
 # install requirements
 RUN apk add --update --no-cache bash ca-certificates curl jq

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # pinned version of the Alpine-tagged 'go' image
-FROM golang:1.21-alpine
+FROM golang:1.22.0-alpine
 
 # install requirements
 RUN apk add --update --no-cache bash ca-certificates curl jq


### PR DESCRIPTION
Fixes the go lang version error

go: github.com/aquasecurity/tfsec/cmd/tfsec@latest: github.com/aquasecurity/tfsec@v1.28.11 requires go >= 1.22.7 (running go 1.21.13; GOTOOLCHAIN=local)

![image](https://github.com/user-attachments/assets/039344c3-dd25-4382-92a4-5d9a7fb6182c)
